### PR TITLE
[FIX] updated dockerfile with debian replacements (stretch was archived)  [sc-16629]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ ARG map=netherlands-latest
 ENV CONTINENT=$continent
 ENV MAP=$map
 
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list
+RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
+
 RUN apt update && apt install wget htop -y
 WORKDIR /opt
 


### PR DESCRIPTION
## Context

Updating Geo container. I was about run this command (documented in the `README`): 

```
# 1. Build docker image 
docker build --no-cache --progress=plain --build-arg continent=europe --build-arg map=netherlands-latest -t seenons/geo:latest -f Dockerfile .
```

An error occurred: 

```
#0 0.814 Err:3 http://security.debian.org/debian-security stretch/updates Release
#0 0.814   404  Not Found [IP: 151.101.194.132 80]
#0 0.817 Ign:4 http://deb.debian.org/debian stretch-updates InRelease
#0 0.828 Err:5 http://deb.debian.org/debian stretch Release
#0 0.828   404  Not Found
#0 0.845 Err:6 http://deb.debian.org/debian stretch-updates Release
#0 0.845   404  Not Found
#0 0.890 Reading package lists...
#0 0.977 E: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
#0 0.977 E: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
#0 0.977 E: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
------
Dockerfile:10
--------------------
   8 |     ENV MAP=$map
   9 |
  10 | >>> RUN apt update && apt install wget htop -y
  11 |     WORKDIR /opt
  12 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt update && apt install wget htop -y" did not complete successfully: exit code: 100
```

It seems that Debian archived the stretch suite to `archive.debian.org`, according to [this message](https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html) from March 2023 (that seems to be effective since April). 

Easy fix here on the `Dockerfile`; replacing sources `deb.debian.org` with `archive.debian.org` solves the problem, as indicated [here](https://stackoverflow.com/questions/76094428/debian-stretch-repositories-404-not-found). 

Notice that this debian distro is in which the `osrm` docker source image is based on, so we could do nothing to update the debian distro, unless we want to rebuild the whole image. Is not worthy in my view. 

Tested locally. Works! 